### PR TITLE
Polynomial blend

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,29 @@ xt = 0.0
 hardness = 100
 y = sigmoid_blend.(f1x, f2x, x, xt, hardness)
 ```
+
+### Blending functions using cubic or quintic polynomials
+
+Cubic or quintic polynomials can also be used to construct a piecewise function that smoothly blends two functions.  The advantage of this approach compared to `sigmoid_blend` is that the blending can be restricted to a small interval defined by the half-width `delta_x`.  The disadvantage of this approach is that the resulting function is only C1 continuous when `cubic_blend` is used, and C2 continuous when `quintic_blend` is used.  The method implemented in this package uses a user-specified transition location (`xt`) and scales the input of the sigmoid function using the input `hardness` in order to adjust the smoothness of the transition between the two functions.
+
+```julia
+x = 0.05
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y1 = cubic_blend(f1x, f2x, x, xt, delta_x)
+y2 = quintic_blend(f1x, f2x, x, xt, delta_x)
+```
+
+`cubic_blend` and `quintic_blend` can also be used with vector inputs using broadcasting.
+
+```julia
+x = -0.25:0.01:0.25
+f1x = x
+f2x = x.^2
+xt = 0.0
+delta_x = 0.1
+y1 = cubic_blend.(f1x, f2x, x, xt, delta_x)
+y2 = quintic_blend.(f1x, f2x, x, xt, delta_x)
+```

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ y = sigmoid_blend.(f1x, f2x, x, xt, hardness)
 
 ### Blending functions using cubic or quintic polynomials
 
-Cubic or quintic polynomials can also be used to construct a piecewise function that smoothly blends two functions.  The advantage of this approach compared to `sigmoid_blend` is that the blending can be restricted to a small interval defined by the half-width `delta_x`.  The disadvantage of this approach is that the resulting function is only C1 continuous when `cubic_blend` is used, and C2 continuous when `quintic_blend` is used.  The method implemented in this package uses a user-specified transition location (`xt`) and scales the input of the sigmoid function using the input `hardness` in order to adjust the smoothness of the transition between the two functions.
+Cubic or quintic polynomials can also be used to construct a piecewise function that smoothly blends two functions.  The advantage of this approach compared to `sigmoid_blend` is that the blending can be restricted to a small interval defined by the half-width `delta_x`.  The disadvantage of this approach is that the resulting function is only C1 continuous when `cubic_blend` is used, and C2 continuous when `quintic_blend` is used.  The method implemented in this package uses a user-specified transition location (`xt`).  The smoothness of the transition between the two functions can be adjusted by modifying `delta_x`, which is the half-width of the transition interval.
 
 ```julia
 x = 0.05

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -11,6 +11,8 @@ export abs_smooth
 export ksmax, ksmin
 export sigmoid
 export sigmoid_blend
+export cubic_blend
+export quintic_blend
 
 include("interpolate.jl")
 export akima_setup

--- a/src/smooth.jl
+++ b/src/smooth.jl
@@ -66,4 +66,34 @@ function sigmoid_blend(f1x, f2x, x, xt, hardness=50)
     return f1x + sx*(f2x-f1x)
 end
 
+"""
+    cubic_blend(f1x, f2x, x, xt, delta_x)
+
+Smoothly transitions the results of functions f1 and f2 using a cubic polynomial,
+with the transition between the functions located at `xt`. delta_x is the half
+width of the smoothing interval.  The resulting function is C1 continuous.
+"""
+function cubic_blend(f1x, f2x, x, xt, delta_x)
+    x = max(x, xt-delta_x)
+    x = min(x, xt+delta_x)
+    xp = (x-xt)/(2*delta_x) + 1/2
+    sx = -2*xp^3 + 3*xp^2
+    return f1x + sx*(f2x-f1x)
+end
+
+"""
+    quintic_blend(f1x, f2x, x, xt, delta_x)
+
+Smoothly transitions the results of functions f1 and f2 using a quintic polynomial,
+with the transition between the functions located at `xt`. delta_x is the half
+width of the smoothing interval.  The resulting function is C2 continuous.
+"""
+function quintic_blend(f1x, f2x, x, xt, delta_x)
+    x = max(x, xt-delta_x)
+    x = min(x, xt+delta_x)
+    xp = (x-xt)/(2*delta_x) + 1/2
+    sx = 6*xp^5 - 15*xp^4 + 10*xp^3
+    return f1x + sx*(f2x-f1x)
+end
+
 # TODO AN: add smooth max/min with cubic splines

--- a/src/smooth.jl
+++ b/src/smooth.jl
@@ -74,11 +74,15 @@ with the transition between the functions located at `xt`. delta_x is the half
 width of the smoothing interval.  The resulting function is C1 continuous.
 """
 function cubic_blend(f1x, f2x, x, xt, delta_x)
-    x = max(x, xt-delta_x)
-    x = min(x, xt+delta_x)
-    xp = (x-xt)/(2*delta_x) + 1/2
-    sx = -2*xp^3 + 3*xp^2
-    return f1x + sx*(f2x-f1x)
+    if x <= xt - delta_x
+        return f1x
+    elseif x >= xt + delta_x
+        return f2x
+    else
+        xp = (x-xt)/(2*delta_x) + 1/2
+        sx = -2*xp^3 + 3*xp^2
+        return f1x + sx*(f2x-f1x)
+    end
 end
 
 """
@@ -89,11 +93,15 @@ with the transition between the functions located at `xt`. delta_x is the half
 width of the smoothing interval.  The resulting function is C2 continuous.
 """
 function quintic_blend(f1x, f2x, x, xt, delta_x)
-    x = max(x, xt-delta_x)
-    x = min(x, xt+delta_x)
-    xp = (x-xt)/(2*delta_x) + 1/2
-    sx = 6*xp^5 - 15*xp^4 + 10*xp^3
-    return f1x + sx*(f2x-f1x)
+    if x <= xt - delta_x
+        return f1x
+    elseif x >= xt + delta_x
+        return f2x
+    else
+        xp = (x-xt)/(2*delta_x) + 1/2
+        sx = 6*xp^5 - 15*xp^4 + 10*xp^3
+        return f1x + sx*(f2x-f1x)
+    end
 end
 
 # TODO AN: add smooth max/min with cubic splines

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,8 +49,8 @@ y = abs_smooth(x, delta_x)
 @test y == 3.0
 
 x = 3.0
-delta_x = 0.0
-y = abs_smooth(x, 0.1)
+delta_x = 0.1
+y = abs_smooth(x, delta_x)
 @test y == 3.0
 
 x = -3.0
@@ -236,6 +236,162 @@ ytest = [-0.24999999999566003,
           0.062500000002604]
 @test isapprox(y, ytest)
 
+# -------------------------
+
+# ------ cubic_blend ---------
+x = -3.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test y == -3.0
+
+x = 3.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test y == 9.0
+
+x = 0.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test y == 0.0
+
+x = -0.1
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test y == f1x
+
+x = 0.1
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test y == f2x
+
+x = -0.05
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test isapprox(y, -0.041796875000000004)
+
+x = 0.05
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend(f1x, f2x, x, xt, delta_x)
+@test isapprox(y, 0.009921875000000004)
+
+# vectorized
+x = -0.25:0.05:0.25
+f1x = x
+f2x = x.^2
+xt = 0.0
+delta_x = 0.1
+y = cubic_blend.(f1x, f2x, x, xt, delta_x)
+ytest = [-0.25,
+         -0.2,
+         -0.15,
+         -0.1,
+         -0.041796875000000004,
+          0.0,
+          0.009921875000000004,
+          0.010000000000000002,
+          0.0225,
+          0.04000000000000001,
+          0.0625]
+@test isapprox(y, ytest)
+
+# -------------------------
+# ------ quintic_blend ---------
+x = -3.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test y == -3.0
+
+x = 3.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test y == 9.0
+
+x = 0.0
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test y == 0.0
+
+x = -0.1
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test y == f1x
+
+x = 0.1
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test y == f2x
+
+x = -0.05
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test isapprox(y, -0.044565429687500005)
+
+x = 0.05
+f1x = x
+f2x = x^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend(f1x, f2x, x, xt, delta_x)
+@test isapprox(y, 0.007416992187499999)
+
+# vectorized
+x = -0.25:0.05:0.25
+f1x = x
+f2x = x.^2
+xt = 0.0
+delta_x = 0.1
+y = quintic_blend.(f1x, f2x, x, xt, delta_x)
+ytest = [ -0.25,
+          -0.2,
+          -0.15,
+          -0.1,
+          -0.044565429687500005,
+           0.0,
+           0.007416992187499999,
+           0.010000000000000002,
+           0.0225,
+           0.04000000000000001,
+           0.0625]
+@test isapprox(y, ytest)
 # -------------------------
 
 # ------- forward/backwards/central/complex diff ----------


### PR DESCRIPTION
This adds `cubic_blend` and `quintic_blend` which are alternatives to sigmoid_blend for blending two functions together.  The advantage of these two functions is that the transition between the two functions is limited to a small interval defined by the half-width `delta_x`.  `cubic_blend` is C1 continuous, whereas `quintic_blend` is C2 continuous.