### PR TITLE
Adaptive ks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 julia = "1"

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -9,6 +9,7 @@ export brent
 include("smooth.jl")
 export abs_smooth
 export ksmax, ksmin
+export ksmax_adaptive, ksmin_adaptive
 export sigmoid
 export sigmoid_blend
 

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -1,5 +1,7 @@
 module FLOWMath
 
+using Parameters
+
 include("quadrature.jl")
 export trapz
 

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -1,7 +1,5 @@
 module FLOWMath
 
-using Parameters
-
 include("quadrature.jl")
 export trapz
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,6 +128,94 @@ x_max_smooth = ksmin(x, hardness)
 
 # -------------------------
 
+# ------ ksmax_adaptive ---------
+x = [0.0, 0.0]
+x_max_smooth = ksmax_adaptive(x)
+@test isapprox(x_max_smooth, 0.0008325546111576975)
+
+# overflow
+x = [1e6, 1e6]
+x_max_smooth = ksmax_adaptive(x)
+@test isapprox(x_max_smooth, 1.0000000008325547e6)
+
+# underflow
+x = [-1e6, -1e6]
+x_max_smooth = ksmax_adaptive(x)
+@test isapprox(x_max_smooth, -999999.9991674453)
+
+# hardness
+x = [0.0, 0.0]
+hardness = 100.0
+x_max_smooth = ksmax_adaptive(x, hardness)
+@test isapprox(x_max_smooth, 0.0008325546111576975)
+
+x = [-0.1, 0.0]
+hardness = 100.0
+x_max_smooth = ksmax_adaptive(x, hardness)
+@test isapprox(x_max_smooth, 4.5398899216870535e-7)
+
+# tolerance
+x = [0.0, 0.0]
+tol = 1e-3
+x_max_smooth = ksmax_adaptive(x, tol=tol)
+@test isapprox(x_max_smooth, 0.013862943611198907)
+
+# smoothing_fraction
+x = [-0.165, 0.0]
+smoothing_fraction = 0.1
+x_max_smooth = ksmax_adaptive(x, smoothing_fraction=smoothing_fraction)
+@test isapprox(x_max_smooth, 5.261253727654178e-6)
+
+x = [-0.165, 0.0]
+smoothing_fraction = 0.2
+x_max_smooth = ksmax_adaptive(x, smoothing_fraction=smoothing_fraction)
+@test isapprox(x_max_smooth, 5.2856933329025475e-6)
+
+# ------ ksmin_adaptive ---------
+x = [0.0, 0.0]
+x_max_smooth = ksmin_adaptive(x)
+@test isapprox(x_max_smooth, -0.0008325546111576975)
+
+# overflow
+x = [1e6, 1e6]
+x_max_smooth = ksmin_adaptive(x)
+@test isapprox(x_max_smooth, 999999.9991674453)
+
+# underflow
+x = [-1e6, -1e6]
+x_max_smooth = ksmin_adaptive(x)
+@test isapprox(x_max_smooth, -1.0000000008325547e6)
+
+# hardness
+x = [0.0, 0.0]
+hardness = 100.0
+x_max_smooth = ksmin_adaptive(x, hardness)
+@test isapprox(x_max_smooth, -0.0008325546111576975)
+
+x = [0.1, 0.0]
+hardness = 100.0
+x_max_smooth = ksmin_adaptive(x, hardness)
+@test isapprox(x_max_smooth, -4.5398899216870535e-7)
+
+# tolerance
+x = [0.0, 0.0]
+tol = 1e-3
+x_max_smooth = ksmin_adaptive(x, tol=tol)
+@test isapprox(x_max_smooth, -0.013862943611198907)
+
+# smoothing_fraction
+x = [0.165, 0.0]
+smoothing_fraction = 0.1
+x_max_smooth = ksmin_adaptive(x, smoothing_fraction=smoothing_fraction)
+@test isapprox(x_max_smooth, -5.261253727654178e-6)
+
+x = [0.165, 0.0]
+smoothing_fraction = 0.2
+x_max_smooth = ksmin_adaptive(x, smoothing_fraction=smoothing_fraction)
+@test isapprox(x_max_smooth, -5.2856933329025475e-6)
+
+# -------------------------
+
 # ------ sigmoid ---------
 x = -0.5
 y = sigmoid(x)


### PR DESCRIPTION
Adds `ksmax_adaptive` and `ksmin_adaptive`, which sets the hardness for the KS function so that the derivative of the KS function with respect to hardness is less than a specified tolerance.  There's a couple differences from the original paper by Poon and Martins.
- First, this method uses Newton's method in the log-log scale rather than the secant method in the log-log scale. This eliminates having to input a step size.
- Second, and more importantly, this implementation makes use of quintic_blend to transition between the two cases where the original hardness is within the tolerance, and the case where the hardness needs to be increased.  This eliminates a discontinuity which was present in the formulation presented in the original paper.  The parameter `smoothing_factor` which can be varied between 0 and 1 is used to adjust the length of the transition.  The default: 0.1, was chosen based on inspection of a two variable ksmax case.
It should be noted that this pull request includes `quintic_blend` which is included in another pull request.
