### PR TITLE
Add complex-step safe versions of a few functions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.3']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FLOWMath"
 uuid = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"
 authors = ["Andrew Ning <aning@byu.edu>"]
-version = "0.4.0"
+version = "0.3.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Andrew Ning <aning@byu.edu>"]
 version = "0.3.2"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FLOWMath"
 uuid = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"
 authors = ["Andrew Ning <aning@byu.edu>"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Smoothing
 - sigmoid blending
 - cubic/quintic polynomial blending
 
+[Complex step safe](https://doi.org/10.1145/838250.838251) versions of
+- `abs`: `abs_cs_safe`
+- `abs2`: `abs2_cs_safe`
+- `norm`: `norm_cs_safe`
+- `dot`: `dot_cs_safe`
+- `atan` (two argument form): `atan_cs_safe`
+
 ### Install
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -334,3 +334,23 @@ savefig("cubic.svg"); nothing # hide
 cubic_blend
 quintic_blend
 ```
+
+### Complex-step safe functions
+The [complex-step derivative approximation](https://doi.org/10.1145/838250.838251) can be used to easily and accurately approximate first derivatives.
+However, the function `f` one wishes to differentiate must be composed of functions that are compatible with the method.
+Most elementary functions are, but a few common ones are not:
+
+  * `abs`
+  * `abs2`
+  * `norm`
+  * `dot`
+
+FLOWMath provides complex-step safe versions of these functions.
+These functions use Julia's multiple dispatch to fall back on the standard implementations when given real arguments, and so shouldn't impose any performance penalty when they are not used with the complex step method.
+
+```@docs
+abs_cs_safe
+abs2_cs_safe
+norm_cs_safe
+dot_cs_safe
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -344,13 +344,15 @@ Most elementary functions are, but a few common ones are not:
   * `abs2`
   * `norm`
   * `dot`
+  * the two argument form of `atan` (often called `atan2` or `arctan2` in other languages)
 
 FLOWMath provides complex-step safe versions of these functions.
-These functions use Julia's multiple dispatch to fall back on the standard implementations when given real arguments, and so shouldn't impose any performance penalty when they are not used with the complex step method.
+These functions use Julia's multiple dispatch to fall back on the standard implementations when given real arguments, and so shouldn't impose any performance penalty when not used with the complex step method.
 
 ```@docs
 abs_cs_safe
 abs2_cs_safe
 norm_cs_safe
 dot_cs_safe
+atan_cs_safe
 ```

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -1,7 +1,9 @@
 module FLOWMath
 
 include("cs_safe.jl")
-export abs_cs_safe
+export abs_cs_safe, abs2_cs_safe
+export norm_cs_safe
+export dot_cs_safe
 
 include("quadrature.jl")
 export trapz

--- a/src/FLOWMath.jl
+++ b/src/FLOWMath.jl
@@ -4,6 +4,7 @@ include("cs_safe.jl")
 export abs_cs_safe, abs2_cs_safe
 export norm_cs_safe
 export dot_cs_safe
+export atan_cs_safe
 
 include("quadrature.jl")
 export trapz

--- a/src/cs_safe.jl
+++ b/src/cs_safe.jl
@@ -1,7 +1,72 @@
-function abs_cs_safe(x::T) where {T<:Complex}
+using LinearAlgebra: norm, dot
+
+
+"""
+    abs_cs_safe(x)
+
+Calculate the absolute value of `x` in a manner compatible with the complex-step derivative approximation.
+
+See also: [`abs`](@ref).
+"""
+abs_cs_safe
+
+@inline function abs_cs_safe(x::T) where {T<:Complex}
     return x*sign(real(x))
 end
 
-function abs_cs_safe(x)
+@inline function abs_cs_safe(x)
     return abs(x)
+end
+
+"""
+    abs2_cs_safe(x)
+
+Calculate the squared absolute value of `x` in a manner compatible with the complex-step derivative approximation.
+
+See also: [`abs2`](@ref).
+"""
+abs2_cs_safe
+
+@inline function abs2_cs_safe(x::T) where {T<:Complex}
+    return abs_cs_safe(x)^2
+end
+
+@inline function abs2_cs_safe(x)
+    return abs2(x)
+end
+
+"""
+    norm_cs_safe(x, p)
+
+Calculate the `p`-norm value of iterable `x` in a manner compatible with the complex-step derivative approximation.
+
+See also: [`norm`](@ref).
+"""
+norm_cs_safe
+
+@inline function norm_cs_safe(x::AbstractArray{T}, p::Real=2) where {T<:Complex}
+    return sum(x.^p)^(1/p)
+end
+
+@inline function norm_cs_safe(x, p::Real=2)
+    return norm(x, p)
+end
+
+"""
+    dot_cs_safe(a, b)
+
+Calculate the dot product of vectors `a` and `b` in a manner compatible with the complex-step derivative approximation.
+
+See also: [`norm`](@ref).
+"""
+dot_cs_safe
+
+@inline function dot_cs_safe(a::AbstractVector{T}, b) where {T<:Complex}
+    # `dot` conjugates its first argument, so we only need to worry about the case where the first argument is complex.
+    # return sum(a.*b)
+    return dot(conj.(a), b)
+end
+
+@inline function dot_cs_safe(a, b)
+    return dot(a, b)
 end

--- a/src/cs_safe.jl
+++ b/src/cs_safe.jl
@@ -70,3 +70,36 @@ end
 @inline function dot_cs_safe(a, b)
     return dot(a, b)
 end
+
+
+"""
+    atan_cs_safe(y, x)
+
+Calculate the two-argument arctangent function in a manner compatible with the complex-step derivative approximation.
+
+See also: [`atan`](@ref).
+"""
+atan_cs_safe
+
+@inline function atan_cs_safe(y, x)
+    return atan_cs_safe(promote(y, x)...)
+end
+
+@inline function atan_cs_safe(y::T, x::T) where {T<:Complex}
+    # Stolen from openmdao/utils/cs_safe.py
+	# a = np.real(y)
+	# b = np.imag(y)
+	# c = np.real(x)
+	# d = np.imag(x)
+	# return np.arctan2(a, c) + 1j * (c * b - a * d) / (a**2 + c**2)
+    a = real(y)
+    b = imag(y)
+    c = real(x)
+    d = imag(x)
+    return complex(atan(a, c), (c * b - a * d) / (a^2 + c^2))
+end
+
+@inline function atan_cs_safe(y::T, x::T) where {T}
+    return atan(y, x)
+end
+

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,8 +5,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-# Bug introduced in FiniteDiff v2.11.1 that prevents passing range-type
-# arguments (like `StepRangeLen`) to
-# finite_difference_jacobian, which should be fixed by
-# https://github.com/JuliaDiff/FiniteDiff.jl/pull/137, aka future version 2.12.2.
-FiniteDiff = "< 2.11.1"
+FiniteDiff = "2.13"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,3 +3,10 @@ FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+# Bug introduced in FiniteDiff v2.11.1 that prevents passing range-type
+# arguments (like `StepRangeLen`) to
+# finite_difference_jacobian, which should be fixed by
+# https://github.com/JuliaDiff/FiniteDiff.jl/pull/137, aka future version 2.12.2.
+FiniteDiff = "< 2.11.1"


### PR DESCRIPTION
I've been using complex-step-safe versions of a few Julia functions for a while now, namely:

  * `abs`, `abs2`
  * `dot`
  * `atan`, the two-argument form

Could these find a home in FLOWMath? I don't think they're available in any other Julia package, and complex-step safe versions of common functions seems to fit the mission of FLOWMath to provide miscellaneous mathematical tools for gradient-based optimization. 